### PR TITLE
Make the cache duration user configurable

### DIFF
--- a/src/component/Settings.vue
+++ b/src/component/Settings.vue
@@ -45,6 +45,21 @@
 				<a href="javascript:void 0" @click.left="resetToDefault('searchServer')" title="Reset to default">&#8635;</a>
 			</div>
 		</section>
+		<section v-if="newSettings.dataSource === 'local'">
+			<hr />
+			<h3>Cache duration</h3>
+			<p>
+				How long the local cache is valid for.
+			</p>
+			<div class="horizontal-field">
+				<select v-model.number="newSettings.cacheDuration">
+					<option value="86400000">1 Day</option>
+					<option value="604800000">7 Days</option>
+					<option value="2592000000">30 Days</option>
+				</select>
+				<a href="javascript:void 0" @click.left="resetToDefault('cacheDuration')" title="Reset to default">&#8635;</a>
+			</div>
+		</section>
 		<section>
 			<hr />
 			<h3>Search delay</h3>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,8 @@ export interface Settings {
 	searchServer: string;
 
 	searchDelay: number;
+
+	cacheDuration: number;
 }
 
 export interface SettingsStore {
@@ -22,6 +24,7 @@ const DEFAULT_SETTINGS: Settings = {
 	dataSource: 'local',
 	searchServer: 'https://tagmaster.bitwolfy.com/',
 	searchDelay: 500,
+	cacheDuration: 24 * 60 * 60 * 1000,
 };
 
 export async function setSettingsStore(settingsStore: SettingsStore | null) {


### PR DESCRIPTION
Github downloads are for some reason unbearably slow for me, taking upwards of 20 minutes for `data.json`. Having to sit though downloading that every day isn't necessary, I don't need a daily refresh for that. In my opinion the tag data is good enough even after a few days. Theres also the possibility of using a metered connection but thats not what I had in mind when doing this.

I don't know how to get the `settingsHolder` from the userscript template so I hacked it together but I'm sure theres a better way to do that. Feel free to modify this.